### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,35 +1,21 @@
 {
-  "ProjectsFound": 2,
+  "PackagesFound": 2,
+  "PackageChanges": [],
+  "Summary": {
+    "CommonPackages": 0,
+    "PackagesConfigured": 2,
+    "FrameworkSpecificPackages": 2,
+    "PackagesChanged": 0,
+    "DirectoryPackagesPropsUpdated": true,
+    "FrameworksSet": "net8.0;net9.0;net10.0",
+    "ProjectsUpdated": 2
+  },
+  "ChangeSummaryText": "No package version changes - this might be a new setup or no updates available",
   "TargetFrameworks": [
     "net8.0",
     "net9.0",
     "net10.0"
   ],
-  "ChangeSummary": [
-    "Microsoft.Extensions.DependencyInjection.Abstractions: 9.0.1 → 9.0.11",
-    "Microsoft.Extensions.Hosting: 9.0.1 → 9.0.11"
-  ],
-  "Timestamp": "2025-11-15 19:16:15",
-  "PackageChanges": [
-    {
-      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.1",
-      "NewVersion": "9.0.11"
-    },
-    {
-      "Package": "Microsoft.Extensions.Hosting",
-      "Framework": "net9.0",
-      "OldVersion": "9.0.1",
-      "NewVersion": "9.0.11"
-    }
-  ],
-  "PackagesFound": 2,
-  "Summary": {
-    "PackagesChanged": 2,
-    "DirectoryPackagesPropsUpdated": true,
-    "FrameworksSet": "net8.0;net9.0;net10.0",
-    "PackagesConfigured": 2,
-    "ProjectsUpdated": 2
-  }
+  "ProjectsFound": 2,
+  "Timestamp": "2025-11-15 20:46:28"
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/8

---

#### What Changed:
- **Projects Updated:** 2
- **Packages Configured:** 2
- **Package Versions Changed:** 0
- **Common Packages:** COMMON_2
- **Framework-Specific Packages:** 2
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**No package version changes** - packages may have been newly configured

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/8
