### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/Source/Zonit.Extensions.Identity.Abstractions/Zonit.Extensions.Identity.Abstractions.csproj
+++ b/Source/Zonit.Extensions.Identity.Abstractions/Zonit.Extensions.Identity.Abstractions.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
 </Project>

--- a/Source/Zonit.Extensions.Identity/Zonit.Extensions.Identity.csproj
+++ b/Source/Zonit.Extensions.Identity/Zonit.Extensions.Identity.csproj
@@ -1,18 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-	</PropertyGroup>
-	
-	<ItemGroup>
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\Zonit.Extensions.Identity.Abstractions\Zonit.Extensions.Identity.Abstractions.csproj" />
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Zonit.Extensions.Identity.Abstractions\Zonit.Extensions.Identity.Abstractions.csproj" />
+  </ItemGroup>
 </Project>

--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,21 +1,22 @@
 {
   "Summary": {
-    "FrameworkSpecificPackages": 2,
-    "PackagesConfigured": 2,
     "FrameworksSet": "net8.0;net9.0;net10.0",
-    "PackagesChanged": 0,
     "CommonPackages": 0,
+    "PackagesConfigured": 2,
+    "ProjectsUpdated": 2,
     "DirectoryPackagesPropsUpdated": true,
-    "ProjectsUpdated": 2
+    "PackagesChanged": 0,
+    "FrameworkSpecificPackages": 2,
+    "PreservedPrivateAssets": 0
   },
+  "Timestamp": "2025-11-17 06:14:21",
+  "ChangeSummaryText": "No package version changes - packages may already be up to date",
+  "PackageChanges": [],
+  "ProjectsFound": 2,
+  "PackagesFound": 2,
   "TargetFrameworks": [
     "net8.0",
     "net9.0",
     "net10.0"
-  ],
-  "ProjectsFound": 2,
-  "PackagesFound": 2,
-  "ChangeSummaryText": "No package version changes - packages may already be up to date",
-  "PackageChanges": [],
-  "Timestamp": "2025-11-17 05:23:40"
+  ]
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/25

---

#### What Changed:
- **Projects Updated:** 2
- **Packages Configured:** 2
- **Package Versions Changed:** 0
- **Common Packages:** COMMON_2
- **Framework-Specific Packages:** 2
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**No package version changes** - packages may have been newly configured

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/25
